### PR TITLE
Abort when the OCSP/CRL exclusion list cannot be fetched

### DIFF
--- a/src/report.sh
+++ b/src/report.sh
@@ -27,8 +27,21 @@ mkdir -p $SHARED_DIR/artifacts/reporting/pshtt_reports
 # hosts to be evaluated for HTTPS compliance, since they are not
 # required to satisfy BOD 18-01.  For more information see here:
 # https://https.cio.gov/guide/#are-federally-operated-certificate-revocation-services-crl-ocsp-also-required-to-move-to-https
-wget https://raw.githubusercontent.com/cisagov/dotgov-data/main/dotgov-websites/ocsp-crl.csv \
-  -O $SHARED_DIR/artifacts/ocsp-crl.csv
+#
+# Fetch to a temporary file and only move it into place once we know we
+# got something.  wget truncates its -O target before the request, so a
+# failed fetch straight to the destination leaves a zero-byte file, and an
+# empty exclusion list silently puts every OCSP/CRL responder back into the
+# denominator of the compliance percentages.
+OCSP_CRL_TMP=$(mktemp)
+if ! wget https://raw.githubusercontent.com/cisagov/dotgov-data/main/dotgov-websites/ocsp-crl.csv \
+  -O "$OCSP_CRL_TMP" || [ ! -s "$OCSP_CRL_TMP" ]; then
+  echo 'Failed to fetch ocsp-crl.csv; refusing to generate reports that would' >&2
+  echo 'understate HTTPS compliance for every OCSP/CRL responder.' >&2
+  rm -f "$OCSP_CRL_TMP"
+  exit 1
+fi
+mv "$OCSP_CRL_TMP" $SHARED_DIR/artifacts/ocsp-crl.csv
 
 # Generate agency reports
 cd $SHARED_DIR/artifacts/reporting/pshtt_reports || exit 1


### PR DESCRIPTION
`src/report.sh` fetches the OCSP/CRL exclusion list and never checks whether the fetch worked:

```sh
wget https://raw.githubusercontent.com/cisagov/dotgov-data/main/dotgov-websites/ocsp-crl.csv \
  -O $SHARED_DIR/artifacts/ocsp-crl.csv
```

There is no `set -e` and no `set -o pipefail` in the script, and the only exit check anywhere is the `cd ... || exit 1` on the next line. wget truncates its `-O` target before it makes the request, so a failed fetch leaves a zero-byte file rather than the previous contents or no file at all. `report.sh` creates `$SHARED_DIR/artifacts/` a few lines earlier, so wget can always create it.

`generate_https_scan_report.py:122-125` then reads it with no emptiness check:

```python
ocsp_exclusions = {}
with open(OCSP_EXCLUSION_CSV_FILE, newline="") as ocsp_file:
    csvreader = csv.reader(ocsp_file)
    ocsp_exclusions = {row[0]: None for row in csvreader}
```

An empty map means `ocsp_domain` is False for every host, so the OCSP and CRL responders go back into the denominator of every percentage and fail every check, because they are plain HTTP by design. That is the whole reason https.cio.gov exempts them and the reason this file exists.

The run still reports success, and `create_all_reports.py` does not check the exit code of each `generate_https_scan_report.py` subprocess either, so the whole day's agency reports go out with an understated compliance number and nothing surfaces it.

Executed, same database contents, only that one file differing. Five compliant sites plus three HTTP-only OCSP responders:

```
A. file fetched (positive control)   bod_1801_percentage 100.0   OCSP rows marked * : 3 of 3
B. wget failed, file 0 bytes         bod_1801_percentage  62.5   OCSP rows marked * : 0 of 3
```

`ocsp-crl.csv` currently holds 68 hosts across 20 base domains, concentrated at dot.gov, faa.gov, uspto.gov, nasa.gov and treasury.gov, so an agency with a handful of eligible domains and several responders takes a large hit.

This fetches to a temporary file, requires it to be non-empty, and only moves it into place on success. Executed against the real URLs in a clean container:

```
OLD, good URL       wget exit=0   size=1322 rows=68
OLD, failing URL    wget exit=8   size=0 content=[]        -> script continues
NEW, failing URL    aborts, exit=1, destination left untouched
NEW, good URL       exit=0        size=1322 rows=68
```

I left `set -euo pipefail` alone deliberately, since it would change the behaviour of the two redis polling loops above. A defensive check on the Python side, treating an empty exclusion file as an error rather than as "no exclusions", would also be reasonable, but the shell is where the failure is swallowed.
